### PR TITLE
Rewrite, improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ $ npm i --save map-o
 
 ```js
 // Dependencies
-var Mapo = require("map-o");
+const mapObject = require("map-o");
 
 // Modify this object
-console.log(Mapo({
+console.log(mapObject({
     location: "Earth"
   , age: 10
-}, function (name, value) {
+}, (value, name) => {
     if (name === "location") {
         return "Location: " + value;
     }
@@ -28,23 +28,34 @@ console.log(Mapo({
     }
 }));
 // => { location: 'Location: Earth', age: 42 }
+
+var obj = {
+    two: 2
+  , nine: 9
+  , ten: 10
+};
+
+// Calculate the squares, but don't override the object
+var squares = mapObject(obj, x => x * x, true);
+console.log("input:", obj);
+// => input: { two: 2, nine: 9, ten: 10 }
+
+console.log("squares:", squares);
+// => squares: { two: 4, nine: 81, ten: 100 }
 ```
 
 ## Documentation
 
-### `Mapo(obj, fn, clone)`
+### `mapObject(obj, fn, clone)`
 Array-map like for objects.
 
 #### Params
 - **Object** `obj`: The input object.
 - **Function** `fn`: A function returning the field values.
-- **Boolean** `clone`: If `true`, the input object will be cloned, so the original object will not be changed.
+- **Boolean|Object** `clone`: If `true`, the input object will be cloned. If `clone` is an object, it will be used as target object.
 
 #### Return
 - **Object** The modified object.
-
-### `proto()`
-Appends the `map` method to the `Object` prototype.
 
 ## How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
@@ -53,6 +64,8 @@ Have an idea? Found a bug? See [how to contribute][contributing].
 If you are using this library in one of your projects, add it in this list. :sparkles:
 
  - [`emojic`](https://github.com/IonicaBizau/emojic#readme)
+
+ - [`engine-flow-types`](https://github.com/jillix/engine-flow-types#readme) by jillix
 
  - [`enny`](https://github.com/IonicaBizau/enny) by jillix
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,11 +1,11 @@
 // Dependencies
-var Mapo = require("../lib");
+const mapObject = require("../lib");
 
 // Modify this object
-console.log(Mapo({
+console.log(mapObject({
     location: "Earth"
   , age: 10
-}, function (name, value) {
+}, (value, name) => {
     if (name === "location") {
         return "Location: " + value;
     }
@@ -15,3 +15,17 @@ console.log(Mapo({
     }
 }));
 // => { location: 'Location: Earth', age: 42 }
+
+var obj = {
+    two: 2
+  , nine: 9
+  , ten: 10
+};
+
+// Calculate the squares, but don't override the object
+var squares = mapObject(obj, x => x * x, true);
+console.log("input:", obj);
+// => input: { two: 2, nine: 9, ten: 10 }
+
+console.log("squares:", squares);
+// => squares: { two: 4, nine: 81, ten: 100 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,33 +9,16 @@ const iterateObject = require("iterate-object");
  * @function
  * @param {Object} obj The input object.
  * @param {Function} fn A function returning the field values.
- * @param {Boolean} clone If `true`, the input object will be cloned, so the original object will not be changed.
+ * @param {Boolean|Object} clone If `true`, the input object will be cloned.
+ * If `clone` is an object, it will be used as target object.
  * @return {Object} The modified object.
  */
 function mapObject(obj, fn, clone) {
-    var dst = obj;
-    if (clone) {
-        dst = typeof clone === "object" ? clone : {};
-    }
-
+    var dst = clone === true ? {} : clone ? clone : obj;
     IterateObject(obj, function (v, n, o) {
         dst[n] = fn(v, n, o);
     });
-
     return dst;
 }
-
-/**
- * proto
- * Appends the `map` method to the `Object` prototype.
- *
- * @name proto
- * @function
- */
-mapObject.proto = function () {
-    Object.prototype.map = function (fn) {
-        return mapObject(this, fn);
-    };
-};
 
 module.exports = mapObject;

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ const iterateObject = require("iterate-object");
  */
 function mapObject(obj, fn, clone) {
     var dst = clone === true ? {} : clone ? clone : obj;
-    IterateObject(obj, function (v, n, o) {
+    iterateObject(obj, (v, n, o) => {
         dst[n] = fn(v, n, o);
     });
     return dst;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,27 +1,28 @@
 // Dependencies
-var IterateObject = require("iterate-object")
-  , Ul = require("ul")
-  ;
+const iterateObject = require("iterate-object");
 
 /**
- * Mapo
+ * mapObject
  * Array-map like for objects.
  *
- * @name Mapo
+ * @name mapObject
  * @function
  * @param {Object} obj The input object.
  * @param {Function} fn A function returning the field values.
  * @param {Boolean} clone If `true`, the input object will be cloned, so the original object will not be changed.
  * @return {Object} The modified object.
  */
-function Mapo(obj, fn, clone) {
+function mapObject(obj, fn, clone) {
+    var dst = obj;
     if (clone) {
-        obj = Ul.clone(obj);
+        dst = typeof clone === "object" ? clone : {};
     }
+
     IterateObject(obj, function (v, n, o) {
-        obj[n] = fn(n, v, o);
+        dst[n] = fn(v, n, o);
     });
-    return obj;
+
+    return dst;
 }
 
 /**
@@ -31,10 +32,10 @@ function Mapo(obj, fn, clone) {
  * @name proto
  * @function
  */
-Mapo.proto = function () {
+mapObject.proto = function () {
     Object.prototype.map = function (fn) {
-        return Mapo(this, fn);
+        return mapObject(this, fn);
     };
 };
 
-module.exports = Mapo;
+module.exports = mapObject;

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "dependencies": {
     "iterate-object": "^1.1.0",
     "ul": "5.0.0"
+  },
+  "devDependencies": {
+    "tester": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "homepage": "https://github.com/IonicaBizau/node-map-o",
   "dependencies": {
-    "iterate-object": "^1.1.0",
-    "ul": "5.0.0"
+    "iterate-object": "^1.3.0"
   },
   "devDependencies": {
     "tester": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "map-o",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Array-map like function for objects.",
   "main": "lib/index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,63 @@
+const tester = require("tester")
+    , mapObject = require("../lib")
+    ;
+
+tester.describe("map-object", test => {
+    test.should("map and override objects", () => {
+        var obj = {
+            location: "Earth"
+          , age: 10
+        };
+        var result = mapObject(obj, (value, name) => {
+            if (name === "location") {
+                return "Location: " + value;
+            }
+
+            if (value === 10) {
+                return 42;
+            }
+        });
+        test.expect(obj.location).toBe("Location: Earth");
+        test.expect(obj.age).toBe(42);
+        test.expect(result).toBe(obj);
+    });
+
+    test.should("map and clone using boolean", () => {
+
+        var obj = {
+            two: 2
+          , nine: 9
+          , ten: 10
+        };
+
+        var squares = mapObject(obj, x => x * x, true);
+        test.expect(squares).toEqual({
+            two: 4,
+            nine: 81,
+            ten: 100
+        });
+        test.expect(squares).toNotBe(obj);
+    });
+
+    test.should("map and clone a specific object", () => {
+
+        var obj = {
+            two: 2
+          , nine: 9
+          , ten: 10
+        };
+
+        var target = {
+            eight: 64
+        };
+
+        var squares = mapObject(obj, x => x * x, target);
+        test.expect(squares).toEqual({
+            two: 4,
+            nine: 81,
+            ten: 100,
+            eight: 64
+        });
+        test.expect(squares).toBe(target);
+    });
+});


### PR DESCRIPTION
- Changed the order of parameters.
- Removed ul as dependency.
- Renamed the function.
- Handle the clone parameter as function
- Added tests
- Improved example.
- :fire: Deprecated the `proto` method.
